### PR TITLE
remove hard-coded checkpoint_callback flag

### DIFF
--- a/deepforest/main.py
+++ b/deepforest/main.py
@@ -127,7 +127,6 @@ class deepforest(pl.LightningModule):
         self.trainer = pl.Trainer(logger=logger,
                                   max_epochs=self.config["train"]["epochs"],
                                   gpus=self.config["gpus"],
-                                  checkpoint_callback=False,
                                   accelerator=self.config["distributed_backend"],
                                   fast_dev_run=self.config["train"]["fast_dev_run"],
                                   callbacks=callbacks,


### PR DESCRIPTION
at the moment it is not possible to have checkpointing since `pl.Trainer` is constructed with hard-coded [checkpoint_callback=False](https://github.com/weecology/DeepForest/blob/4f787bed481bc9184937383823e017c0942b4fca/deepforest/main.py#L130)

an example to have [checkpointing](https://pytorch-lightning.readthedocs.io/en/stable/common/weights_loading.html) later after this fix.
~~~
callback = ModelCheckpoint(dirpath='temp/dir',
                                 monitor='box_recall', 
                                 mode="max",
                                 save_top_k=3,
                                 filename="box_recall-{epoch:02d}-{box_recall:.2f}")
model.create_trainer(logger=TensorBoardLogger(save_dir='logdir/'), 
                                  callbacks=[callback])
model.trainer.fit(model)
~~~